### PR TITLE
Testing PR open/close actions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,9 +7,15 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        hugo-version:
+          - '0.141.0'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - uses: ./.github/actions/build-hugo-site
+        with:
+          hugo-version: ${{ matrix.hugo-version }}


### PR DESCRIPTION
Content of the change is to make it so that the nightly gets hugo version from matrix, with the intent that we'll have a hugo-latest build soon