### PR TITLE
Existing AWS playbook content

### DIFF
--- a/content/aws/how-tos/_index.md
+++ b/content/aws/how-tos/_index.md
@@ -1,0 +1,4 @@
+---
+layout: topic
+title: How-Tos
+---

--- a/content/aws/how-tos/allow-external-user-assume-role.md
+++ b/content/aws/how-tos/allow-external-user-assume-role.md
@@ -1,0 +1,92 @@
+---
+layout: section
+title: "How-To: Allow an External IAM Identity Center User to Assume a Role"
+---
+
+When we collaborate between teams, we often need to allow users from one AWS organization to access resources in another.
+In this guide, we will walk through the steps to allow an external IAM Identity Center user to assume a role in your AWS account.
+
+The model we'll use here allows the external account to control which users can assume the role, while we maintain control over the permissions granted by the role.
+The idea is that we will create a role which can be assumed by any user who has a certain permission set from the external account.
+The external account will have to create a permission set that allows users to assume the role we create, and then assign that permission set to the users/groups who need access.
+
+The target role will need a trust policy to allow the external users to assume it, and therefore the external team will need to provide the following information to the team deploying the target role:
+
+* The AWS account ID of the external account.
+* The name of the permission set that will be created in the external account.
+* The AWS region where the permission set will be created in the external account.
+
+The external team will need the following information from the team deploying the target role:
+
+* The AWS account ID where the target role will be created.
+* The name of the target role that will be created.
+
+## Creating the Target Role
+
+1. In the IAM console of the account that the external team needs to access, create a new role.
+2. For the trusted entity, select "Custom trust policy". Use the following trust policy, replacing the `EXTERNAL_ACCOUNT_ID`, `PERMISSION_SET_NAME`, and `AWS_REGION` with the appropriate values:
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::EXTERNAL_ACCOUNT_ID:root"
+          },
+          "Action": "sts:AssumeRole",
+          "Condition": {
+            "ArnLike": {
+              "aws:PrincipalArn": "arn:aws:iam::EXTERNAL_ACCOUNT_ID:role/aws-reserved/sso.amazonaws.com/AWS_REGION/AWSReservedSSO_PERMISSION_SET_NAME*"
+            }
+          }
+        }
+      ]
+    }
+    ```
+    Note that the `AWS_REGION/` is not needed if the region is `us-east-1`. In that case, be sure not to leave a double slash in the ARN!
+
+3. Attach the necessary permissions to the role that will allow the external users to access the resources they need.
+
+## Creating the Permission Set in the External Account
+
+The external team will need to create and provision a group and permission set to assume the role. Most of the procedure is the same as described in the how-to on [linking an identity center group to a role](../link-identity-center-group-role), but when creating the permission set, they will need to use a custom permission set with the following inline policy, replacing the `TARGET_ACCOUNT_ID` and `ROLE_NAME` with the appropriate values:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::TARGET_ACCOUNT_ID:role/ROLE_NAME"
+    }
+  ]
+}
+```
+
+## Assuming the role: SSO Profile
+
+To assume this role using an SSO profile, you'll need to configure two profiles in your `~/.aws/config` file: one for the SSO login (to have access to the permission set) and one to then assume the target role.
+
+This will look something like the following:
+
+```ini
+[profile jump-profile]
+sso_session = EXTERNAL_SSO_SESSION
+sso_account_id = EXTERNAL_ACCOUNT_ID
+sso_role_name = PERMISSION_SET_NAME
+
+[profile assume-role-profile]
+role_arn = arn:aws:iam::TARGET_ACCOUNT_ID:role/ROLE_NAME
+source_profile = jump-profile
+sso_session = EXTERNAL_SSO_SESSION
+```
+
+The `jump-profile` is used to log in to the SSO session and get access to the permission set, while the `assume-role-profile` is used to assume the target role using the permissions from the permission set.
+
+## Assuming the role: Console
+
+1. Assume the role for the permission set. Go to the AWS SSO user portal (start URL) and log in with the user that has the permission set assigned, and select the role associated with the permission set.
+2. Switch roles by clicking on the account name in the upper right, and then clicking "Switch Role". Enter the TARGET_ACCOUNT_ID and ROLE_NAME, and click "Switch Role".
+

--- a/content/aws/how-tos/link-identity-center-group-role.md
+++ b/content/aws/how-tos/link-identity-center-group-role.md
@@ -1,0 +1,22 @@
+---
+layout: section
+title: "How-To: Link an Identity Center Group to a Role"
+---
+
+The goal here is to use Identity Center Groups as a list of people, and to allow anyone in that Group to assume an role in the AWS account.
+The actual IAM Role will be automatically created and managed by Identity Center, on the basis of a Permission Set that we create in Identity Center.
+Note that, if you don't see the "Multi-Account settings" section in the Identity Center console, you might need to create an AWS Organization first.
+
+1. **Create the Group.** From the IAM Identity Center console, click on Groups and create a new group. If you already have users, you can add them at this stage.
+2. **Create the Permission Set.** From the IAM Identity Center console, click on Permission sets (under Multi-Account settings) and create a new permission set. We generally recommend using the AWS managed policies unless you have specific needs that require a custom policy.
+3. **Assign the Group and Permission Set to the AWS account.** Go to "AWS Accounts" under the "Multi-Account settings" section in the Identity Center console and select the checkbox next to the AWS account(s) you want to assign the Group and Permission Set to. Then click on "Assign users or groups," switch to the Groups tab, and select the Group you created in step 1. Click Next, and select the Permission Set you created in step 2. Click Next, review the assignment, and click "Submit" to complete the process.
+4. **Create users and add them to the Group.** You can create users in Identity Center and add them to the Group you created in step 1. We recommend using email addresses as usernames, and sending the users an email invitation to set up their accounts.
+
+## Groups/Permission Sets to consider
+
+These use AWS managed permission sets. Group name first; AWS managed policy name after the colon.
+
+* Admins: AdministratorAccess
+* Billing: Billing
+* Developers: PowerUserAccess
+* ReadOnly: ReadOnlyAccess

--- a/content/aws/how-tos/local-sso-setup.md
+++ b/content/aws/how-tos/local-sso-setup.md
@@ -1,0 +1,58 @@
+---
+layout: section
+title: "How-To: Set up IAM Identity Center (AWS SSO) on your Computer"
+---
+
+The goal of this guide is to get you set up to use IAM Identity Center (formerly AWS SSO). This will allow you to use the AWS CLI and other tools that rely on AWS credentials.
+We assume you've already installed the AWS CLI and have set up your AWS Identity Center user.
+
+## Configuring AWS CLI for IAM Identity Center
+
+The following steps are based on using the `aws configure sso` command, which basically just sets up a profile in your AWS CLI configuration. You can also directly edit the `~/.aws/config` file.
+
+1. Gather the following information about your AWS Identity Center deployment:
+   - SSO Start URL: This is listed on the IAM Identity Center page in the AWS Console, on the right, under "AWS access portal URLs" (I usually use the IPv4 only URL).
+   - SSO Region: This is listed as the "Primary Region" under Settings Summary on the IAM Identity Center page in the AWS Console.
+   - AWS Account ID: This is the 12-digit account ID of the AWS account you want to access; find this in the upper right of your AWS Console.
+   - SSO Role Name: This is the name of the permission set associated with the profile you want to use.
+2. Run the following command to configure your AWS CLI for SSO:
+
+   ```bash
+   aws configure sso
+   ```
+
+3. Follow the prompts to enter the information you gathered in step 1.
+
+This essentially just adds information to your `~/.aws/config` file.
+
+
+## Using AWS CLI with IAM Identity Center
+
+To try logging in with your new SSO profile, run the following command:
+
+```bash
+aws sso login --profile my-profile-name
+```
+
+The CLI should open a browser or prompt you to complete device authorization.
+You'll need to sign in as your AWS Identity Center user and complete MFA if it is enabled.
+Approve the sign-in flow if prompted, which will allow the AWS CLI to retrieve temporary credentials for your profile.
+Once you've done that, you can validate that you are logged in by running the following command:
+
+```bash
+aws sts get-caller-identity --profile my-profile-name
+```
+
+This will return a JSON object if it succeeds.
+All the information about your AWS Identity Center user and the permissions you have will be encoded in the `Arn` field of the output.
+If you are not logged in, or if your session has expired, you'll get an error message instead.
+
+Although you can use the `--profile` flag on the AWS CLI to specify which profile to use, it is usually more convenient to set either the `AWS_PROFILE` or `AWS_DEFAULT_PROFILE` environment variable to the name of the profile you want to use.
+This way, you don't have to specify the profile every time you run an AWS CLI command.
+I use [direnv](https://direnv.net/) to automatically set the `AWS_PROFILE` environment variable when I navigate to a directory that contains an `.envrc` file with the following content:
+
+```bash
+export AWS_PROFILE=my-profile-name
+```
+
+This way, I automatically set the `AWS_PROFILE` environment variable to the correct profile for the project in that directory.

--- a/content/aws/understanding/_index.md
+++ b/content/aws/understanding/_index.md
@@ -1,0 +1,4 @@
+---
+layout: topic
+title: Understanding
+---

--- a/content/aws/understanding/authenticating.md
+++ b/content/aws/understanding/authenticating.md
@@ -1,0 +1,63 @@
+---
+layout: section
+title: Ways of Authenticating to AWS
+---
+
+AWS provides a number of ways to "log in" (authenticate) and access resources.
+This document will cover the various methods, and give our recommendations for which to use when.
+
+## Big Idea: Role-Based Access Control (RBAC)
+
+There are a number of approaches to connect permissions to users.
+For the most part, we recommend using role based access control (RBAC), where you define roles that have certain permissions, and then allow users to assume those roles.
+This is in contrast to user-based access control, where you define permissions for each individual user, or access control lists, where you define permissions for each individual resource.
+In RBAC, a given user may have the ability to assume different roles in different contexts, and the permissions of the user are determined by the role they assume. 
+The AWS permission model is built on this idea.
+Speaking more generally, RBAC allows an "entity" to assume a role -- in AWS, that entity could be a human user or another resource (like an EC2 instance or a GitHub Actions Workflow).
+
+In AWS, you can create roles in the IAM section of the AWS Console, or you can provision permission sets in IAM Identity Center, which will automatically create a role for you.
+An AWS IAM Role consists of two main parts: a trust policy, which defines who can assume the role, and a permissions policy, which defines what permissions the role has once it's assumed.
+The trust policy of an IAM Role can allow AWS resources (such as EC2 instances) or other entities to assume the role -- in fact, your user that assumes the role can be thought of as an entity that AWS knows about.
+Much of the rest of this document is about various ways you can get "inside" AWS, so that you can assume the role.
+
+Because the ability to create roles is a powerful permission, you may need Administrator permissions to create them.
+
+## IAM Users
+
+Under most circumstances, we recommend against using IAM Users.
+IAM Users are long-term credentials that are associated with a single person or application.
+Our main use case for IAM Users is for service accounts, which are used by external tools to access AWS resources.
+For example, IAM Users used to be the recommended way to have GitHub Actions Workflows access AWS resources, but now we have a better way (OpenID Connect, covered below).
+
+Only use IAM Users if there is no other option.
+
+## IAM Identity Center (formerly AWS SSO)
+
+As part of what I must assume was an effort to confuse new users, AWS rebranded AWS SSO to IAM Identity Center.
+This is managed in the IAM Identity Center section of the AWS Console, not the IAM section.
+We recommend using IAM Identity Center for all human users who need to access AWS resources.
+
+IAM Identity Center allows you to define permission sets, and then assign those permission sets to users or groups of users.
+You can have one IAM Identity Center instance for your AWS Organization, and from the organization's management account, you provision permission sets to any of the accounts in the organization.
+The process of assigning a permission set to a user or group must take place in the context of an AWS Account, so when doing this in the IAM Identity Center console, you do this in the AWS accounts subsection of the multi-account permissions.
+We recommend assigning permissions to groups, and then assigning users to those groups.
+When you assign a permission set to a group for an AWS account, IAM Identity Center creates an IAM Role in that account, and the trust policy of that role allows users who are assigned the permission set to assume the role.
+These roles are named in the format `AWSReservedSSO_<permission-set-name>_<random-string>`, and you can see them in the IAM console of the account to which you provisioned the permission set.
+
+In the approach we recommend, you will use AWS IAM Identity Center as the identity provider, i.e., the thing that manages users and their credentials.
+In principle, you could use an external identity provider (like Google Workspace) for this, instead of having users create a separate set of credentials in AWS IAM Identity Center.
+This might be worth pursuing if we migrate to a single OMSF AWS organization.
+
+## OpenID Connect (OIDC)
+
+OpenID Connect (OIDC) is a way for external tools to authenticate without using long-term credentials.
+This is what we recommend for applications that need to access AWS resources, such as GitHub Actions Workflows.
+With OIDC, you can create an IAM Role with a trust policy that allows the GitHub Actions OIDC provider to assume the role, and then you can specify conditions in the trust policy to restrict which workflows can assume the role.
+This is a much more secure way to allow applications to access AWS resources.
+
+
+## Root User Email
+
+The root user email is the email address associated with the AWS account.
+You can sign in to the AWS Management Console using the root user email and password, but this should only be used for initial account setup and as a "break glass" account in case of emergencies.
+There are a very small number of things that can only be done with the root user, but for day-to-day operations, you should use an IAM Identity Center user.

--- a/content/aws/understanding/sso-profiles.md
+++ b/content/aws/understanding/sso-profiles.md
@@ -1,0 +1,37 @@
+---
+layout: section
+title: AWS SSO Profiles
+---
+
+When you log in using IAM Identity Center users, we recommend using profiles on your local machine to help you manage your credentials and access to different AWS accounts and roles.
+These profiles are stored in the `~/.aws/config` file and are used by the AWS CLI and other tools to authenticate your requests.
+
+Your `~/.aws/config` file will contain entries that look like this:
+
+```ini
+[profile my-sso-profile]
+sso_session = my-sso-session
+sso_account_id = 123456789012
+sso_role_name = MySSORole
+
+[sso-session my-sso-session]
+sso_start_url = https://my-sso-portal.awsapps.com/start
+sso_region = us-east-2
+sso_registration_scopes = sso:account:access
+```
+
+You'll usually have one `sso-session` entry per AWS organization (technically, per IAM Identity Center instance, and there is typically one of those per organization), and then multiple `profile` entries that reference that session for different accounts and roles.
+In my own setup, I have 3 `sso-session` entries: for my personal AWS organization, for the Eco-Infra AWS organization, and for the OMSF AWS organization.
+The `sso_start_url` is the URL of the IAM Identity Center user portal for that organization. The `sso_region` is the region where IAM Identity Center is deployed for that organization (not necessarily where you will deploy resources).
+For `sso_registration_scopes`, you'll probably always want to use `sso:account:access`, which allows you to access all accounts that you've been granted access to.
+
+Each `profile` entry references an `sso-session`, and there can be many `profile` entries that reference the same `sso-session`.
+For example, I have an administration profile for each member account of each organization that I administer.
+Each `profile` will reference the organization's `sso_session`, and it will specify the account ID of the member account. I provision all member accounts with my `AdministratorAccess` permission set, so the `sso_role_name` is `AdministratorAccess`.
+The `sso_role_name` will always be the name of the permission set you've created in IAM Identity Center and provisioned into the account. (Don't forget that you need to provision permission sets into accounts to create roles.)
+
+You can also create profiles that take on specific roles in other accounts.
+To do this, you create a profile to assume the role.
+That profile can use a `source_profile` that references a profile that uses SSO to authenticate.
+Essentially, you use the `source_profile` to authenticate with SSO, and then you assume the other role using that profile.
+The permission set from the source profile needs permission to assume that role, and the role needs to trust the source profile's role, but this is a common way to manage access to different accounts and roles without needing multiple logins.


### PR DESCRIPTION
This migrates the existing content of the omsf-eco-infra/aws-playbooks repo into the OMSF playbooks repo. Text should be unchanged; this is moves it so that playbooks infra can build it.